### PR TITLE
change ContextMeasure request param to bring back missed shots as well

### DIFF
--- a/stats/shot_chart_detail.py
+++ b/stats/shot_chart_detail.py
@@ -111,7 +111,7 @@ class ShotChartDetailRequester(GenericRequester):
                 'AheadBehind': '', 
                 'ClutchTime': '',
                 'ContextFilter': '',
-                'ContextMeasure': 'PTS',
+                'ContextMeasure': 'FGA',
                 'DateFrom': '',
                 'DateTo': '',
                 'EndPeriod': '',


### PR DESCRIPTION
ContextMeasure was PTS, changing it to FGA means that both misses and makes are returned from the api