### PR TITLE
Splitting Gooey code out for slim cmdline build, Dockerfile for linux builds

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.9-bullseye
+
+WORKDIR /app
+
+RUN apt update
+RUN apt install -y libpq-dev build-essential
+
+COPY requirements_no_gui.txt requirements_no_gui.txt
+
+RUN pip3 install pip --upgrade
+RUN pip3 install -r requirements_no_gui.txt
+
+COPY stats/ /app/stats
+
+COPY scripts/release/build_no_gui.sh .
+
+RUN chmod +x build_no_gui.sh
+
+CMD ["./build_no_gui.sh"]

--- a/requirements_no_gui.txt
+++ b/requirements_no_gui.txt
@@ -1,0 +1,15 @@
+requests==2.26.0
+certifi==2020.12.5
+cffi==1.14.5
+chardet==4.0.0
+cryptography
+idna==2.10
+peewee==3.14.8
+pycparser==2.20
+PyMySQL==1.0.0
+python-dotenv==0.15.0
+six==1.15.0
+urllib3==1.26.5
+psycopg2==2.9.1
+psycopg2-binary==2.9.1
+pyinstaller

--- a/scripts/release/build.sh
+++ b/scripts/release/build.sh
@@ -1,1 +1,2 @@
-pyinstaller --windowed --paths=stats stats/nba_sql.py -F
+#!/bin/bash
+pyinstaller --windowed -n nba_sql --paths=stats stats/gui.py -F

--- a/scripts/release/build_docker.sh
+++ b/scripts/release/build_docker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+## Script to build an executable in a linux container.
+rm -rf build/ dist/
+mkdir dist
+
+DOCKER_BUILDKIT=1 docker build --tag nba-sql-builder -f docker/Dockerfile.build .
+
+DIST_PATH="$PWD/dist"
+
+docker run -v $DIST_PATH:/app/dist/ nba-sql-builder

--- a/scripts/release/build_exe.txt
+++ b/scripts/release/build_exe.txt
@@ -1,1 +1,1 @@
-py -m PyInstaller --windowed --paths=stats stats\nba_sql.py -F
+py -m PyInstaller --windowed -n nba_sql --paths=stats stats\gui.py -F

--- a/scripts/release/build_no_gui.sh
+++ b/scripts/release/build_no_gui.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pyinstaller --paths=stats stats/nba_sql.py -F

--- a/stats/args.py
+++ b/stats/args.py
@@ -1,4 +1,3 @@
-from gooey import GooeyParser
 from utils import generate_valid_seasons
 
 """
@@ -6,26 +5,10 @@ Creates a parser.
 """
 
 
-def create_parser():
+def create_parser(parser):
     """
     Creates and returns a Gooey parser.
     """
-
-    parser = GooeyParser(description="nba-sql")
-
-    mode_parser = parser.add_mutually_exclusive_group(
-        required=True,
-        gooey_options={
-            'initial_selection': 0
-        })
-    mode_parser.add_argument(
-        '--default_mode',
-        help='Mode to create the database and load historic data. Use this mode when creating a new database or when trying to load a specific season or a range of seasons.',
-        action='store_true')
-    mode_parser.add_argument(
-        '--current_season_mode',
-        help='Mode to refresh the current season. Use this mode on an existing database to update it with the latest data.',
-        action='store_true')
 
     parser.add_argument(
         '--database',
@@ -49,23 +32,6 @@ def create_parser():
         help="Database Username (Not Needed For SQLite)",
         default=None)
 
-    parser.add_argument(
-        '--password',
-        help="Database Password (Not Needed For SQLite)",
-        widget='PasswordField',
-        default=None)
-
-    valid_seasons = generate_valid_seasons()
-    last_loadable_season = valid_seasons[-1]
-
-    parser.add_argument(
-        '--seasons',
-        dest='seasons',
-        default=[last_loadable_season],
-        choices=valid_seasons,
-        widget='Listbox',
-        nargs="*",
-        help='The seasons flag loads the database with the specified season.  The format of the season should be in the form "YYYY-YY".  The default behavior is loading the current season.')
 
     parser.add_argument(
         '--create-schema',
@@ -79,15 +45,6 @@ def create_parser():
         dest='request_gap',
         default='.7',
         help='This flag exists to prevent rate limiting, and injects the desired amount of time inbetween requesting resources.')
-
-    parser.add_argument(
-        '--skip-tables',
-        action='store',
-        nargs="*",
-        default='',
-        choices=['player_season', 'player_game_log', 'play_by_play', 'pgtt', 'shot_chart_detail', 'game', 'event_message_type', 'team', 'player', ''],
-        widget='Listbox',
-        help='Use this option to skip loading certain tables.')
 
     #To fix issue https://github.com/mpope9/nba-sql/issues/56
     parser.add_argument(

--- a/stats/gui.py
+++ b/stats/gui.py
@@ -1,0 +1,101 @@
+from nba_sql import main
+from args import create_parser
+
+from gooey import Gooey
+from gooey import GooeyParser
+
+import codecs
+import sys
+
+
+"""
+This is a wrapper, to allow building the cmdline executable without
+having to include the full GUI libs.
+"""
+
+# This fixes an issue with Gooey and PyInstaller.
+if sys.stdout.encoding != 'UTF-8':
+    sys.stdout = codecs.getwriter('utf-8')(sys.stdout.buffer, 'strict')
+if sys.stderr.encoding != 'UTF-8':
+    sys.stderr = codecs.getwriter('utf-8')(sys.stderr.buffer, 'strict')
+
+# This 'fixes' an issue with printing in the Gooey console, kinda sorta not really.
+class Unbuffered(object):
+   def __init__(self, stream):
+       self.stream = stream
+   def write(self, data):
+       self.stream.write(data)
+       self.stream.flush()
+   def writelines(self, datas):
+       self.stream.writelines(datas)
+       self.stream.flush()
+   def __getattr__(self, attr):
+       return getattr(self.stream, attr)
+
+sys.stdout = Unbuffered(sys.stdout)
+
+
+## Bad practice? Yes. Any other alternative? Not at this point.
+## Only enable Gooey if there are no arguments passed to the script.
+if len(sys.argv)>=2:
+    if not '--ignore-gooey' in sys.argv:
+        sys.argv.append('--ignore-gooey')
+
+
+@Gooey(
+    program_name='nba-sql',
+    program_description='An application to build a database of NBA data.',
+    header_show_title=True)
+def gui_main():
+    parser = GooeyParser(description="nba-sql")
+    create_parser(parser)
+
+    # Add the 'mode args' that the regular python arg parse doesn't support.
+    mode_parser = parser.add_mutually_exclusive_group(
+        required=True,
+        gooey_options={
+            'initial_selection': 0
+        })
+    mode_parser.add_argument(
+        '--default_mode',
+        help='Mode to create the database and load historic data. Use this mode when creating a new database or when trying to load a specific season or a range of seasons.',
+        action='store_true')
+    mode_parser.add_argument(
+        '--current_season_mode',
+        help='Mode to refresh the current season. Use this mode on an existing database to update it with the latest data.',
+        action='store_true')
+
+    parser.add_argument(
+        '--password',
+        help="Database Password (Not Needed For SQLite)",
+        widget='PasswordField',
+        default=None)
+
+    valid_seasons = generate_valid_seasons()
+    last_loadable_season = valid_seasons[-1]
+
+    parser.add_argument(
+        '--seasons',
+        dest='seasons',
+        default=[last_loadable_season],
+        choices=valid_seasons,
+        widget='Listbox',
+        nargs="*",
+        help='The seasons flag loads the database with the specified season.  The format of the season should be in the form "YYYY-YY".  The default behavior is loading the current season.')
+
+    parser.add_argument(
+        '--skip-tables',
+        action='store',
+        nargs="*",
+        default='',
+        choices=['player_season', 'player_game_log', 'play_by_play', 'pgtt', 'shot_chart_detail', 'game', 'event_message_type', 'team', 'player', ''],
+        widget='Listbox',
+        help='Use this option to skip loading certain tables.')
+
+    args = parser.parse_args()
+
+    main(args)
+
+
+if __name__ == "__main__":
+    gui_main()


### PR DESCRIPTION
To address [mpope9#69](https://github.com/mpope9/nba-sql/issues/69)

scripts/release/build_docker.sh will create a Linux executable without Gooey, much smaller.
scripts/release/build.sh will create the Gooey executable. No docker for that yet.

Moved Gooey code to stats/gui.py, stats/nba_sql.py not defaults to a slim cmdline client.

New requirements.txt file to not include Gooey and wx.