### PR TITLE
Fix for issue 78. 

### DIFF
--- a/stats/player_game_log.py
+++ b/stats/player_game_log.py
@@ -36,8 +36,6 @@ class PlayerGameLogRequester(GenericRequester):
         Override method to setup temp table.
         """
         super().create_ddl()
-        self.settings.db.bind([PlayerGameLogTemp])
-        self.settings.db.create_tables([PlayerGameLogTemp], safe=True)
  
     def populate_temp(self):
         """

--- a/stats/shot_chart_detail.py
+++ b/stats/shot_chart_detail.py
@@ -24,8 +24,6 @@ class ShotChartDetailRequester(GenericRequester):
         Override method to setup temp table.
         """
         super().create_ddl()
-        self.settings.db.bind([ShotChartDetailTemp])
-        self.settings.db.create_tables([ShotChartDetailTemp], safe=True)
 
     def finalize(self, filter_predicate):
         """


### PR DESCRIPTION
Problem here is that the function create_ddl() for both, ShotChartDetailRequester and PlayerGameLogRequester attempt to create the temp tables ShotChartDetailTemp and PlayerGameLogTemp twice. Once inside the __init__ functions and once inside the create_ddl functions. This PR simply removes code that creates the temp table from the create_ddl functions.

This is a fix for issue https://github.com/mpope9/nba-sql/issues/78