### PR TITLE
Fixing duplicate row error -- PGTT and Player Season

### DIFF
--- a/stats/general_requester.py
+++ b/stats/general_requester.py
@@ -46,6 +46,7 @@ class GenericRequester:
 
     def populate(self):
         """
-        Bulk insert.
+        Bulk insert. Remove row cache from object once finished.
         """
         insert_many(self.settings, self.table, self.rows)
+        self.rows = []

--- a/stats/player_general_traditional_total.py
+++ b/stats/player_general_traditional_total.py
@@ -40,9 +40,10 @@ class PlayerGeneralTraditionalTotalRequester(GenericRequester):
 
         column_mapping = get_rowset_mapping(result_sets, column_names)
 
+        season_id_int = season_id_to_int(season_id)
         for row in rowset:
             new_row = {column_name: row[row_index] for column_name, row_index in column_mapping.items()}
-            new_row['season_id'] = season_id_to_int(season_id)
+            new_row['season_id'] = season_id_int
             self.rows.append(new_row)
 
         super().populate()

--- a/stats/player_season.py
+++ b/stats/player_season.py
@@ -40,9 +40,10 @@ class PlayerSeasonRequester(GenericRequester):
 
         column_mapping = get_rowset_mapping(result_sets, column_names)
 
+        season_id_int = season_id_to_int(season_id)
         for row in rowset:
             new_row = {column_name: row[row_index] for column_name, row_index in column_mapping.items()}
-            new_row['season_id'] = season_id_to_int(season_id)
+            new_row['season_id'] = season_id_int
             self.rows.append(new_row)
 
         super().populate()


### PR DESCRIPTION
A reproduction of this is loading multiple seasons at once for the PGTT table.

The PR removes the row cache. Seems it needs to be blown away between multiple seasons being loaded. Also two minor optimizations of converting the season string to an int outside of the inner loop.