### PR TITLE
fix: Support for shot_cart_detail mid-season update from scratch

### DIFF
--- a/stats/nba_sql.py
+++ b/stats/nba_sql.py
@@ -323,7 +323,7 @@ def current_season_mode(settings, request_gap, skip_tables, quiet):
             shot_chart_requester.populate()
             time.sleep(request_gap)
 
-        scd_predicate = player_game_log_requester.temp_table_except_predicate()
+        scd_predicate = shot_chart_requester.temp_table_except_predicate()
         shot_chart_requester.finalize(scd_predicate)
 
     if quiet:

--- a/stats/shot_chart_detail.py
+++ b/stats/shot_chart_detail.py
@@ -45,6 +45,21 @@ class ShotChartDetailRequester(GenericRequester):
         """
         super().create_ddl()
 
+    def temp_table_except_predicate(self):
+        """
+        This runs an EXCEPT between the temp table and the non-temp table to find
+        the new games.
+
+        This is a silly way to do this, but I wanted a quick copy/paste to unblock
+        something else.
+        """
+        regular_query = ShotChartDetail.select(ShotChartDetail.game_id)
+        temp_query = ShotChartDetailTemp.select(ShotChartDetailTemp.game_id)
+
+        expt = temp_query - regular_query
+
+        return expt.select_from(expt.c.game_id)
+
     def finalize(self, filter_predicate):
         """
         This function finishes loading shot_chart_detail by inserting all valid


### PR DESCRIPTION
Decouples the state of the stored shot charts from the player game log games. This allows for shot charts to be populated mid-season even if they've never been pulled before.